### PR TITLE
Create users:peppy.md

### DIFF
--- a/_posts/users:peppy.md
+++ b/_posts/users:peppy.md
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+ID:2
+_____________
+<s>this page is a stub, feel free to add on to any anything</s>
+<h1>peppy</h1>
+peppy is the creator of osu!(stable/beta/cutting-edge), osu!stream, and osu!lazer.
+<h2>History</h2>
+peppy, inspired by the <i>Osu! Tatakae! Ouendan</i> series publicly launched osu! (not created) on Sept. 17 2007.<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/2007#september'>[1]</a>
+The IRC (Internet Relay Chat) was launched at some point in December.<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/2007#november'>[1]</a>
+(which could be connected via a IRC client at cho.ppy.sh  or irc.ppy.sh).
+on Oct. 6 2007, peppy added rankings. Ranks at this time were based in ranked score<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/Online_rankings/osu%21'>[1]</a>
+  


### PR DESCRIPTION
Leaving out some information so marking this as a stub.
HTML:
```
<!DOCTYPE html>
ID:2
_____________
<s>this page is a stub, feel free to add on to any anything</s>
<h1>peppy</h1>
peppy is the creator of osu!(stable/beta/cutting-edge), osu!stream, and osu!lazer.
<h2>History</h2>
peppy, inspired by the <i>Osu! Tatakae! Ouendan</i> series publicly launched osu! (not created) on Sept. 17 2007.<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/2007#september'>[1]</a>
The IRC (Internet Relay Chat) was launched at some point in December.<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/2007#november'>[1]</a>
(which could be connected via a IRC client at cho.ppy.sh  or irc.ppy.sh).
on Oct. 6 2007, peppy added rankings. Ranks at this time were based in ranked score<a href='https://osu.ppy.sh/wiki/en/History_of_osu%21/Online_rankings/osu%21'>[1]</a>
```
  `