### PR TITLE
Revert "horizontal rule removals"

### DIFF
--- a/docs/content/en/maps/disco_prince.md
+++ b/docs/content/en/maps/disco_prince.md
@@ -18,7 +18,9 @@ allowed_elements: ["table", "tr", "td", "th"]
 This page does not list much information about this particular person/map/feature/etc. (stub)
 </th><th>
 
-# Disco Prince
+---
+
+## Disco Prince
 
 Disco Prince was the first map uploaded with the beatmap submission system, (not the first map to be created with the osu! editor). The mapper is peppy, and the file format is "osu file format v3."
 

--- a/docs/content/en/users/WhiteCat.md
+++ b/docs/content/en/users/WhiteCat.md
@@ -17,6 +17,8 @@ peppypedia-current: [true]
 This page does not list much information about this particular person/map/feature/etc. (stub)
 </th><th>
 
+---
+
 # BlackDog5
 
  BlackDog5, formerly known as WhiteCat and ezHG(#4 as of 11/11/22) is a well-known osu! top player who achieved #1 on Oct. 6 2022; however was sniped by mrekk on April, 08 2021.[^1][^2] WhiteCat has changed their username to BlackDog5 on January 19, 2023.[^3]

--- a/docs/content/en/users/jhlee0133.md
+++ b/docs/content/en/users/jhlee0133.md
@@ -16,7 +16,7 @@ peppypedia-current: [true]
 This page does not list much information about this particular person/map/feature/etc. (stub)
 </th><th>
 
-# jhlee0133
+## jhlee0133
 
 ---
 

--- a/docs/content/en/users/mrekk.md
+++ b/docs/content/en/users/mrekk.md
@@ -16,6 +16,7 @@ peppypedia-current: [true]
 
 # mrekk
 
+## mrekk
 ---
 mrekk is the current #1 ranked osu! player in performance points who prospered #1 on April, 08, 2020.[^1] He is also the first australian #1 since eyup who peaked #1 in ranked score during 2007.[^2][^3] mrekk also has the curernt performance points record (1371.45pp) thus beating the old record set by aetrna(1356.97pp, 1357 excl. decimals).[^4][^5] As of September 04, 2023, mrekk has won 12 tournament badges.[^6]
 


### PR DESCRIPTION
testingv2 now has more commits than `master`. i cannot allow this to prevent conflicts.

(thanks @qwrmolly)